### PR TITLE
Add File Reader options and improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,15 @@
     </licenses>
     <properties>
         <javac.version>1.8</javac.version>
-        <kafka.version>2.4.0</kafka.version>
-        <confluent.version>5.3.2</confluent.version>
-        <hadoop.version>2.9.0</hadoop.version>
+        <kafka.version>5.4.1-ccs</kafka.version>
+        <confluent.version>5.4.1</confluent.version>
+        <hadoop.version>2.9.2</hadoop.version>
         <avro.version>1.8.1</avro.version>
         <parquet.version>1.9.0</parquet.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.4</easymock.version>
         <powermock.version>1.6.6</powermock.version>
+        <github.version>1.108</github.version>
         <okHttpVersion>2.4.0</okHttpVersion>
         <minimalJsonVersion>0.9.1</minimalJsonVersion>
         <file.encoding>UTF-8</file.encoding>
@@ -77,10 +78,20 @@
     </distributionManagement>
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>${github.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceConnectorConfig.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceConnectorConfig.java
@@ -4,6 +4,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.protocol.types.Field;
 
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,12 @@ public class FsSourceConnectorConfig extends AbstractConfig {
     public static final String TOPIC = "topic";
     private static final String TOPIC_DOC = "Topic to copy data to.";
 
+    public static final String POLL_INTERVAL_MS = "poll.interval.ms";
+    public static final String POLL_INTERVAL_MS_DOC = "Interval in ms between filesystem polls";
+
+    public static final String INCLUDE_METADATA = "include.metadata";
+    public static final String INCLUDE_METADATA_DOC = "Whether or not to include file metadata in the output value";
+
     public FsSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
     }
@@ -28,7 +35,9 @@ public class FsSourceConnectorConfig extends AbstractConfig {
     public static ConfigDef conf() {
         return new ConfigDef()
                 .define(FS_URIS, Type.LIST, Importance.HIGH, FS_URIS_DOC)
-                .define(TOPIC, Type.STRING, Importance.HIGH, TOPIC_DOC);
+                .define(TOPIC, Type.STRING, Importance.HIGH, TOPIC_DOC)
+                .define(POLL_INTERVAL_MS, Type.LONG, 0, Importance.HIGH, POLL_INTERVAL_MS_DOC)
+                .define(INCLUDE_METADATA, Type.BOOLEAN, Boolean.FALSE, Importance.HIGH, INCLUDE_METADATA_DOC);
     }
 
     public List<String> getFsUris() {
@@ -39,4 +48,7 @@ public class FsSourceConnectorConfig extends AbstractConfig {
         return this.getString(TOPIC);
     }
 
+    public Long getPollIntervalMs() { return this.getLong(POLL_INTERVAL_MS); }
+
+    public boolean getIncludeMetadata() { return this.getBoolean(INCLUDE_METADATA); }
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -7,7 +7,10 @@ import com.github.mmolimar.kafka.connect.fs.policy.Policy;
 import com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils;
 import com.github.mmolimar.kafka.connect.fs.util.Version;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -27,6 +30,7 @@ public class FsSourceTask extends SourceTask {
     private AtomicBoolean stop;
     private FsSourceTaskConfig config;
     private Policy policy;
+    private long maxBatchSize;
 
     @Override
     public String version() {
@@ -37,6 +41,7 @@ public class FsSourceTask extends SourceTask {
     public void start(Map<String, String> properties) {
         try {
             config = new FsSourceTaskConfig(properties);
+            maxBatchSize = config.getLong(FsSourceTaskConfig.MAX_BATCH_SIZE);
 
             if (config.getClass(FsSourceTaskConfig.POLICY_CLASS).isAssignableFrom(Policy.class)) {
                 throw new ConfigException("Policy class " +
@@ -61,27 +66,59 @@ public class FsSourceTask extends SourceTask {
         stop = new AtomicBoolean(false);
     }
 
+    private SchemaAndValue appendMetadata(SchemaAndValue source, FileMetadata metadata, boolean isLast) {
+        Schema sourceSchema = source.schema();
+        Map<String, Object> sourceValue = (Map<String, Object>) source.value();
+        SchemaBuilder builder = SchemaBuilder.struct()
+                .name(sourceSchema.name())
+                .optional();
+        for (Field field : sourceSchema.fields()) {
+            builder.field(field.name(), field.schema());
+        }
+        Map<String, Object> value = new HashMap<>();
+        for (Field field : sourceSchema.fields()) {
+            value.put(field.name(), sourceValue.get(field.name()));
+        }
+
+        SchemaAndValue policyMetadata = policy.buildMetadata(metadata, isLast);
+        builder.field("_file_metadata", policyMetadata.schema());
+        value.put("_file_metadata", policyMetadata.value());
+        return new SchemaAndValue(builder.build(), value);
+    }
+
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
         while (stop != null && !stop.get() && !policy.hasEnded()) {
+            if (config.getPollIntervalMs() > 0)
+                Thread.sleep(config.getPollIntervalMs());
             log.trace("Polling for new data");
 
             final List<SourceRecord> results = new ArrayList<>();
             List<FileMetadata> files = filesToProcess();
-            files.forEach(metadata -> {
-                try (FileReader reader = policy.offer(metadata, context.offsetStorageReader())) {
-                    log.info("Processing records for file {}", metadata);
-                    while (reader.hasNext()) {
-                        results.add(convert(metadata, reader.currentOffset(), reader.next()));
+
+            int count = 0;
+            for (FileMetadata metadata : files) {
+                SchemaAndValue key = policy.buildKey(metadata);
+                Map<String, Object> lastOffset = context.offsetStorageReader().offset((Map<String, Object>) key.value());
+                try (FileReader reader = policy.offer(metadata, lastOffset)) {
+                    if (reader != null) {
+                        while (reader.hasNext() && (maxBatchSize == 0 || count < maxBatchSize)) {
+                            log.info("Processing records for file {}", metadata);
+                            SchemaAndValue sAndV = reader.next();
+                            boolean isLast = !reader.hasNext();
+                            if (config.getIncludeMetadata())
+                                sAndV = appendMetadata(sAndV, metadata, isLast);
+                            results.add(convert(metadata, policy, lastOffset, reader.currentOffset(), sAndV, isLast));
+                            count++;
+                        }
                     }
                 } catch (ConnectException | IOException e) {
                     //when an exception happens reading a file, the connector continues
                     log.error("Error reading file from FS: " + metadata.getPath() + ". Keep going...", e);
                 }
-            });
-            return results;
+                return results;
+            }
         }
-
         return null;
     }
 
@@ -92,7 +129,7 @@ public class FsSourceTask extends SourceTask {
                     .collect(Collectors.toList());
         } catch (IOException | ConnectException e) {
             //when an exception happens executing the policy, the connector continues
-            log.error("Cannot retrive files to process from FS: " + policy.getURIs() + ". Keep going...", e);
+            log.error("Cannot retrieve files to process from FS: " + policy.getURIs() + ". Keep going...", e);
             return Collections.EMPTY_LIST;
         }
     }
@@ -102,19 +139,17 @@ public class FsSourceTask extends SourceTask {
         return StreamSupport.stream(iterable.spliterator(), false);
     }
 
-    private SourceRecord convert(FileMetadata metadata, Offset offset, Struct struct) {
+    private SourceRecord convert(FileMetadata metadata, Policy policy, Map<String, Object> lastOffset, Offset recordOffset, SchemaAndValue snv, boolean isLast) {
+        SchemaAndValue key = policy.buildKey(metadata);
+        Map<String, Object> value = (Map<String, Object>) key.value();
         return new SourceRecord(
-                new HashMap<String, Object>() {
-                    {
-                        put("path", metadata.getPath());
-                        //TODO manage blocks
-                        //put("blocks", metadata.getBlocks().toString());
-                    }
-                },
-                Collections.singletonMap("offset", offset.getRecordOffset()),
+                value,
+                policy.buildOffset(metadata, lastOffset, recordOffset, isLast),
                 config.getTopic(),
-                struct.schema(),
-                struct
+                key.schema(),
+                value,
+                snv.schema(),
+                snv.value()
         );
     }
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTaskConfig.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTaskConfig.java
@@ -5,6 +5,9 @@ import org.apache.kafka.common.config.ConfigDef;
 import java.util.Map;
 
 public class FsSourceTaskConfig extends FsSourceConnectorConfig {
+    public static final String MAX_BATCH_SIZE = "max.batch.size";
+    public static final String MAX_BATCH_SIZE_DOC = "Maximum number of records to extract from the file per polling pass. Defaults to unlimited.";
+    public static final long MAX_BATCH_SIZE_DEFAULT = 0;
 
     public static final String POLICY_PREFIX = "policy.";
     public static final String FILE_READER_PREFIX = "file_reader.";
@@ -23,6 +26,9 @@ public class FsSourceTaskConfig extends FsSourceConnectorConfig {
     public static final String FILE_READER_CLASS = FILE_READER_PREFIX + "class";
     private static final String FILE_READER_CLASS_DOC = "File reader class to read files from the FS.";
 
+    public static final String POLICY_PROPAGATE_ERRORS = POLICY_PREFIX + "propagate.errors";
+    private static final String POLICY_PROPAGATE_ERRORS_DOC = "Whether or not the policy should propagate or continue when encountering an error";
+
     public FsSourceTaskConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
     }
@@ -33,9 +39,11 @@ public class FsSourceTaskConfig extends FsSourceConnectorConfig {
 
     public static ConfigDef conf() {
         return FsSourceConnectorConfig.conf()
+                .define(MAX_BATCH_SIZE, ConfigDef.Type.LONG, MAX_BATCH_SIZE_DEFAULT, ConfigDef.Importance.HIGH, MAX_BATCH_SIZE_DOC)
                 .define(POLICY_CLASS, ConfigDef.Type.CLASS, ConfigDef.Importance.HIGH, POLICY_CLASS_DOC)
                 .define(POLICY_RECURSIVE, ConfigDef.Type.BOOLEAN, Boolean.TRUE, ConfigDef.Importance.LOW, POLICY_RECURSIVE_DOC)
                 .define(POLICY_REGEXP, ConfigDef.Type.STRING, ".*", ConfigDef.Importance.MEDIUM, POLICY_REGEXP_DOC)
+                .define(POLICY_PROPAGATE_ERRORS, ConfigDef.Type.BOOLEAN, Boolean.FALSE, ConfigDef.Importance.MEDIUM, POLICY_PROPAGATE_ERRORS_DOC)
                 .define(FILE_READER_CLASS, ConfigDef.Type.CLASS, ConfigDef.Importance.HIGH, FILE_READER_CLASS_DOC);
     }
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/FileMetadata.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/FileMetadata.java
@@ -1,16 +1,20 @@
 package com.github.mmolimar.kafka.connect.fs.file;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FileMetadata {
     private String path;
     private long length;
+    private Map<String,Object> opts;
     private List<BlockInfo> blocks;
 
     public FileMetadata(String path, long length, List<BlockInfo> blocks) {
         this.path = path;
         this.length = length;
         this.blocks = blocks;
+        this.opts = new HashMap<>();
     }
 
     public String getPath() {
@@ -24,6 +28,10 @@ public class FileMetadata {
     public List<BlockInfo> getBlocks() {
         return blocks;
     }
+
+    public Object getOpt(String key) { return opts.get(key); }
+
+    public void setOpt(String key, Object value) { opts.put(key, value); }
 
     @Override
     public String toString() {

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/FileMetadata.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/FileMetadata.java
@@ -7,12 +7,14 @@ import java.util.Map;
 public class FileMetadata {
     private String path;
     private long length;
+    private long modTime;
     private Map<String,Object> opts;
     private List<BlockInfo> blocks;
 
-    public FileMetadata(String path, long length, List<BlockInfo> blocks) {
+    public FileMetadata(String path, long length, long modTime, List<BlockInfo> blocks) {
         this.path = path;
         this.length = length;
+        this.modTime = modTime;
         this.blocks = blocks;
         this.opts = new HashMap<>();
     }
@@ -25,6 +27,10 @@ public class FileMetadata {
         return length;
     }
 
+    public long getModTime() {
+        return modTime;
+    }
+
     public List<BlockInfo> getBlocks() {
         return blocks;
     }
@@ -35,7 +41,7 @@ public class FileMetadata {
 
     @Override
     public String toString() {
-        return String.format("[path = %s, length = %s, blocks = %s]", path, length, blocks);
+        return String.format("[path = %s, length = %s, modTime = %s, blocks = %s]", path, length, modTime, blocks);
     }
 
     @Override
@@ -45,8 +51,9 @@ public class FileMetadata {
 
         FileMetadata metadata = (FileMetadata) object;
         if (this.path.equals(metadata.getPath()) &&
-                this.length == metadata.length &&
-                this.blocks.equals(metadata.getBlocks())) {
+            this.length == metadata.length &&
+            this.modTime == metadata.modTime &&
+            this.blocks.equals(metadata.getBlocks())) {
             return true;
         }
         return false;

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AbstractFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AbstractFileReader.java
@@ -2,7 +2,7 @@ package com.github.mmolimar.kafka.connect.fs.file.reader;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.SchemaAndValue;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -15,13 +15,13 @@ public abstract class AbstractFileReader<T> implements FileReader {
     private final Path filePath;
     private ReaderAdapter<T> adapter;
 
-    public AbstractFileReader(FileSystem fs, Path filePath, ReaderAdapter adapter, Map<String, Object> config) {
+    public AbstractFileReader(FileSystem fs, Path filePath, Map<String, Object> config) {
         if (fs == null || filePath == null) {
             throw new IllegalArgumentException("fileSystem and filePath are required");
         }
         this.fs = fs;
         this.filePath = filePath;
-        this.adapter = adapter;
+        this.adapter = buildAdapter(config);
 
         Map<String, Object> readerConf = config.entrySet().stream()
                 .filter(entry -> entry.getKey().startsWith(FILE_READER_PREFIX))
@@ -30,6 +30,8 @@ public abstract class AbstractFileReader<T> implements FileReader {
     }
 
     protected abstract void configure(Map<String, Object> config);
+
+    protected abstract ReaderAdapter<T> buildAdapter(Map<String, Object> config);
 
     protected FileSystem getFs() {
         return fs;
@@ -40,7 +42,7 @@ public abstract class AbstractFileReader<T> implements FileReader {
         return filePath;
     }
 
-    public final Struct next() {
+    public final SchemaAndValue next() {
         return adapter.apply(nextRecord());
     }
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AgnosticFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AgnosticFileReader.java
@@ -4,7 +4,7 @@ import com.github.mmolimar.kafka.connect.fs.file.Offset;
 import com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.SchemaAndValue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -26,8 +26,7 @@ public class AgnosticFileReader extends AbstractFileReader<AgnosticFileReader.Ag
     private List<String> parquetExtensions, avroExtensions, sequenceExtensions, delimitedExtensions;
 
     public AgnosticFileReader(FileSystem fs, Path filePath, Map<String, Object> config) throws IOException {
-        super(fs, filePath, new AgnosticAdapter(), config);
-
+        super(fs, filePath, config);
         try {
             reader = (AbstractFileReader) readerByExtension(fs, filePath, config);
         } catch (RuntimeException | IOException e) {
@@ -35,6 +34,11 @@ public class AgnosticFileReader extends AbstractFileReader<AgnosticFileReader.Ag
         } catch (Throwable t) {
             throw new IOException("An error has ocurred when creating a concrete reader", t);
         }
+    }
+
+    @Override
+    protected ReaderAdapter<AgnosticRecord> buildAdapter(Map<String, Object> config) {
+        return new AgnosticAdapter();
     }
 
     private FileReader readerByExtension(FileSystem fs, Path filePath, Map<String, Object> config)
@@ -106,7 +110,7 @@ public class AgnosticFileReader extends AbstractFileReader<AgnosticFileReader.Ag
         }
 
         @Override
-        public Struct apply(AgnosticRecord ag) {
+        public SchemaAndValue apply(AgnosticRecord ag) {
             return ag.adapter.apply(ag.record);
         }
     }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/FileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/FileReader.java
@@ -2,26 +2,20 @@ package com.github.mmolimar.kafka.connect.fs.file.reader;
 
 import com.github.mmolimar.kafka.connect.fs.file.Offset;
 import org.apache.hadoop.fs.Path;
-import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.SchemaAndValue;
 
 import java.io.Closeable;
 import java.util.Iterator;
-import java.util.function.Function;
 
-public interface FileReader extends Iterator<Struct>, Closeable {
+public interface FileReader extends Iterator<SchemaAndValue>, Closeable {
 
     Path getFilePath();
 
     boolean hasNext();
 
-    Struct next();
+    SchemaAndValue next();
 
     void seek(Offset offset);
 
     Offset currentOffset();
-}
-
-@FunctionalInterface
-interface ReaderAdapter<T> extends Function<T, Struct> {
-
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
@@ -8,6 +8,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.parquet.avro.AvroParquetReader;
@@ -37,11 +38,16 @@ public class ParquetFileReader extends AbstractFileReader<GenericRecord> {
 
 
     public ParquetFileReader(FileSystem fs, Path filePath, Map<String, Object> config) throws IOException {
-        super(fs, filePath, new GenericRecordToStruct(), config);
+        super(fs, filePath, config);
 
         this.offset = new ParquetOffset(0);
         this.reader = initReader();
         this.closed = false;
+    }
+
+    @Override
+    protected ReaderAdapter<GenericRecord> buildAdapter(Map<String, Object> config) {
+        return new GenericRecordToStruct();
     }
 
     private ParquetReader<GenericRecord> initReader() throws IOException {
@@ -163,8 +169,8 @@ public class ParquetFileReader extends AbstractFileReader<GenericRecord> {
         }
 
         @Override
-        public Struct apply(GenericRecord record) {
-            return (Struct) avroData.toConnectData(record.getSchema(), record).value();
+        public SchemaAndValue apply(GenericRecord record) {
+            return avroData.toConnectData(record.getSchema(), record);
         }
     }
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ReaderAdapter.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ReaderAdapter.java
@@ -1,0 +1,7 @@
+package com.github.mmolimar.kafka.connect.fs.file.reader;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface ReaderAdapter<T> extends Function<T, org.apache.kafka.connect.data.SchemaAndValue> {
+}

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/TextFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/TextFileReader.java
@@ -1,9 +1,12 @@
 package com.github.mmolimar.kafka.connect.fs.file.reader;
 
 import com.github.mmolimar.kafka.connect.fs.file.Offset;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -27,21 +30,62 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
     public static final String FILE_READER_TEXT_FIELD_NAME_VALUE = FILE_READER_SEQUENCE_FIELD_NAME_PREFIX + "value";
     public static final String FILE_READER_TEXT_ENCODING = FILE_READER_TEXT + "encoding";
 
+    public static final String FILE_READER_LINES_SKIP = FILE_READER_PREFIX + "lines.skip";
+    public static final String FILE_READER_FILES_GZIPPED = FILE_READER_PREFIX + "gzipped";
+
     private final TextOffset offset;
     private String currentLine;
     private boolean finished = false;
-    private LineNumberReader reader;
+    protected LineNumberReader reader;
     private Schema schema;
     private Charset charset;
+    private boolean gzipped;
+    private long linesSkip;
 
     public TextFileReader(FileSystem fs, Path filePath, Map<String, Object> config) throws IOException {
-        super(fs, filePath, new TxtToStruct(), config);
-        this.reader = new LineNumberReader(new InputStreamReader(fs.open(filePath), this.charset));
+        super(fs, filePath, config);
+        this.reader = buildReader(fs, filePath, config);
         this.offset = new TextOffset(0);
+    }
+
+    protected LineNumberReader buildReader(FileSystem fs, Path filePath, Map<String, Object> config) throws IOException {
+        gzipped = Boolean.parseBoolean((String) config.get(FILE_READER_FILES_GZIPPED));
+        return buildReader(fs, filePath, gzipped);
+    }
+
+    protected LineNumberReader buildReader(FileSystem fs, Path filePath, boolean gzipped) throws IOException {
+        if (gzipped)
+            return new LineNumberReader(new InputStreamReader(new GzipCompressorInputStream(fs.open(getFilePath()))));
+        else
+            return new LineNumberReader(new InputStreamReader(fs.open(filePath), this.charset));
+    }
+
+    @Override
+    protected ReaderAdapter<TextRecord> buildAdapter(Map<String, Object> config) {
+        return new TxtToStruct();
     }
 
     @Override
     protected void configure(Map<String, Object> config) {
+        buildSchema(config);
+        if (config.get(FILE_READER_TEXT_ENCODING) == null ||
+                config.get(FILE_READER_TEXT_ENCODING).toString().equals("")) {
+            this.charset = Charset.defaultCharset();
+        } else {
+            this.charset = Charset.forName(config.get(FILE_READER_TEXT_ENCODING).toString());
+        }
+        Object lineSkipString = config.get(FILE_READER_LINES_SKIP);
+        if (lineSkipString != null) {
+            try {
+                this.linesSkip = Long.parseLong((String) lineSkipString);
+            } catch (NumberFormatException e) {
+                throw new ConfigException(FILE_READER_LINES_SKIP + " property must be a number(long). Got: " +
+                        config.get(FILE_READER_LINES_SKIP));
+            }
+        }
+    }
+
+    protected void buildSchema(Map<String, Object> config) {
         String valueFieldName;
         if (config.get(FILE_READER_TEXT_FIELD_NAME_VALUE) == null ||
                 config.get(FILE_READER_TEXT_FIELD_NAME_VALUE).toString().equals("")) {
@@ -52,13 +96,6 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
         this.schema = SchemaBuilder.struct()
                 .field(valueFieldName, Schema.STRING_SCHEMA)
                 .build();
-
-        if (config.get(FILE_READER_TEXT_ENCODING) == null ||
-                config.get(FILE_READER_TEXT_ENCODING).toString().equals("")) {
-            this.charset = Charset.defaultCharset();
-        } else {
-            this.charset = Charset.forName(config.get(FILE_READER_TEXT_ENCODING).toString());
-        }
     }
 
     @Override
@@ -69,20 +106,30 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
             return false;
         } else {
             try {
-                while (true) {
-                    String line = reader.readLine();
-                    offset.setOffset(reader.getLineNumber());
-                    if (line == null) {
-                        finished = true;
-                        return false;
-                    }
-                    currentLine = line;
-                    return true;
-                }
+                return readNext();
             } catch (IOException ioe) {
                 throw new IllegalStateException(ioe);
             }
         }
+    }
+
+    protected boolean readNext() throws IOException {
+        String line = null;
+        if (linesSkip > 1) {
+            for (int i = 0; i < linesSkip; i++) {
+                line = reader.readLine();
+            }
+            offset.setOffset((long) (Math.floor(reader.getLineNumber() / (float) linesSkip)));
+        } else {
+            line = reader.readLine();
+            offset.setOffset(reader.getLineNumber());
+        }
+        if (line == null) {
+            finished = true;
+            return false;
+        }
+        currentLine = line;
+        return true;
     }
 
     @Override
@@ -102,17 +149,26 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
             throw new IllegalArgumentException("Record offset must be greater than 0");
         }
         try {
-            if (offset.getRecordOffset() < reader.getLineNumber()) {
-                this.reader = new LineNumberReader(new InputStreamReader(getFs().open(getFilePath())));
+            int effectiveLineNumber = reader.getLineNumber();
+            if (linesSkip > 1) {
+                effectiveLineNumber = (int) Math.floor(reader.getLineNumber() / (float) linesSkip);
+            }
+            if (offset.getRecordOffset() < effectiveLineNumber) {
+                this.reader = buildReader(getFs(), getFilePath(), gzipped);
                 currentLine = null;
             }
+            int lineNumber = 0;
             while ((currentLine = reader.readLine()) != null) {
-                if (reader.getLineNumber() - 1 == offset.getRecordOffset()) {
-                    this.offset.setOffset(reader.getLineNumber());
+                if (linesSkip > 1)
+                    for (int i = 0; i < linesSkip - 1; i++)
+                        currentLine = reader.readLine();
+                lineNumber = (linesSkip > 1) ? (int) Math.floor(reader.getLineNumber() / (float) linesSkip) : reader.getLineNumber();
+                if (lineNumber - 1 == offset.getRecordOffset()) {
+                    this.offset.setOffset(lineNumber);
                     return;
                 }
             }
-            this.offset.setOffset(reader.getLineNumber());
+            this.offset.setOffset(lineNumber);
         } catch (IOException ioe) {
             throw new ConnectException("Error seeking file " + getFilePath(), ioe);
         }
@@ -126,6 +182,10 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
     @Override
     public void close() throws IOException {
         reader.close();
+    }
+
+    public Schema getSchema() {
+        return schema;
     }
 
     public static class TextOffset implements Offset {
@@ -145,18 +205,19 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
         }
     }
 
-    static class TxtToStruct implements ReaderAdapter<TextRecord> {
+    protected static class TxtToStruct implements ReaderAdapter<TextRecord> {
 
         @Override
-        public Struct apply(TextRecord record) {
-            return new Struct(record.schema)
+        public SchemaAndValue apply(TextRecord record) {
+            Struct struct = new Struct(record.schema)
                     .put(record.schema.fields().get(0), record.value);
+            return new SchemaAndValue(struct.schema(), struct);
         }
     }
 
-    static class TextRecord {
-        private final Schema schema;
-        private final String value;
+    protected static class TextRecord {
+        public final Schema schema;
+        public final String value;
 
         public TextRecord(Schema schema, String value) {
             this.schema = schema;

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/FileSchemaReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/FileSchemaReader.java
@@ -22,7 +22,7 @@ public class FileSchemaReader implements SchemaReader {
     private FileSystem fs;
 
     public FileSchemaReader(FileSystem fs, Map<String, Object> config) throws IOException {
-        filepath = (Path)config.get(PATH);
+        filepath = new Path((String) config.get(PATH));
         this.fs = fs;
     }
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/FileSchemaReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/FileSchemaReader.java
@@ -1,0 +1,33 @@
+package com.github.mmolimar.kafka.connect.fs.file.reader.schema;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.lf5.util.StreamUtils;
+import org.kohsuke.github.GitHubBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig.FILE_READER_PREFIX;
+
+public class FileSchemaReader implements SchemaReader {
+    private static final String SCHEMA_READER_PREFIX = FILE_READER_PREFIX + "schema.reader.";
+    public static final String PATH = SCHEMA_READER_PREFIX + "path";
+
+    private Path filepath;
+    private FileSystem fs;
+
+    public FileSchemaReader(FileSystem fs, Map<String, Object> config) throws IOException {
+        filepath = (Path)config.get(PATH);
+        this.fs = fs;
+    }
+
+    @Override
+    public String readSchema() throws IOException {
+        return new String(StreamUtils.getBytes(fs.open(filepath)), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/GithubSchemaReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/GithubSchemaReader.java
@@ -1,0 +1,44 @@
+package com.github.mmolimar.kafka.connect.fs.file.reader.schema;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.kohsuke.github.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig.FILE_READER_PREFIX;
+
+public class GithubSchemaReader implements SchemaReader {
+    public static final String SCHEMA_READER_PREFIX = FILE_READER_PREFIX + "schema.reader.";
+    public static final String AUTH_TOKEN = SCHEMA_READER_PREFIX + "auth.token";
+    public static final String REPO = SCHEMA_READER_PREFIX + "repo";
+    public static final String PATH = SCHEMA_READER_PREFIX + "path";
+    public static final String TAG = SCHEMA_READER_PREFIX + "tag";
+
+    private String schema;
+    private String repoName;
+    private String authToken;
+    private String filepath;
+    private GitHub github;
+    private GHRepository repo;
+    private String tag;
+
+
+    public GithubSchemaReader(FileSystem fs, Map<String, Object> config) throws IOException {
+        repoName = (String)config.get(REPO);
+        authToken = (String)config.get(AUTH_TOKEN);
+        filepath = (String)config.get(PATH);
+        tag = (String) config.get(TAG);
+        github = new GitHubBuilder().withOAuthToken(authToken).build();
+        repo = github.getRepository(repoName);
+    }
+
+    @Override
+    public String readSchema() throws IOException {
+        if (schema != null)
+            return schema;
+        GHContent content = repo.getFileContent(filepath, tag);
+        schema = content.getContent();
+        return schema;
+    }
+}

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/SchemaReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/schema/SchemaReader.java
@@ -1,0 +1,8 @@
+package com.github.mmolimar.kafka.connect.fs.file.reader.schema;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface SchemaReader {
+    public String readSchema() throws IOException;
+}

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -300,7 +300,7 @@ public abstract class AbstractPolicy implements Policy {
     }
 
     @Override
-    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast) {
+    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset) {
         SchemaBuilder metadataBuilder = SchemaBuilder.struct()
                 .name("com.rentpath.filesource.Metadata")
                 .optional();
@@ -314,7 +314,7 @@ public abstract class AbstractPolicy implements Policy {
     }
 
     @Override
-    public Map<String, Object> buildOffset(FileMetadata metadata, long recordOffset) {
+    public Map<String, Object> buildOffset(FileMetadata metadata, long recordOffset, Map<String, Object> priorOffset) {
         return Collections.singletonMap("offset", recordOffset);
     }
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
@@ -135,7 +135,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
     }
 
     @Override
-    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast) {
+    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset) {
         SchemaBuilder metadataBuilder = SchemaBuilder.struct()
                 .name("com.rentpath.filesource.WatcherMetadata")
                 .optional();
@@ -143,6 +143,9 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
         metadataBuilder.field("offset", Schema.INT64_SCHEMA);
         metadataBuilder.field("last", Schema.BOOLEAN_SCHEMA);
         metadataBuilder.field("bulk", Schema.BOOLEAN_SCHEMA);
+        metadataBuilder.field("watchKey", Schema.STRING_SCHEMA);
+        metadataBuilder.field("bulkPath", Schema.STRING_SCHEMA);
+        metadataBuilder.field("priorBulkPath", Schema.OPTIONAL_STRING_SCHEMA); // will be null for the very first bulk file we ingest for a given watch key
         Schema schema = metadataBuilder.build();
 
         Struct metadataValue = new Struct(schema);
@@ -150,19 +153,33 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
         metadataValue.put("offset", offset);
         metadataValue.put("last", isLast);
         metadataValue.put("bulk", (Boolean) metadata.getOpt(BULK_OPT));
+        metadataValue.put("watchKey", (String) metadata.getOpt(WATCH_KEY_OPT));
+        metadataValue.put("bulkPath", (String) connectorOffset.get("bulkPath"));
+        metadataValue.put("priorBulkPath", (String) connectorOffset.get("priorBulkPath"));
 
         return new SchemaAndValue(schema, metadataValue);
     }
 
     @Override
-    public Map<String, Object> buildOffset(FileMetadata metadata, long recordOffset) {
-        return new HashMap<String, Object>() {
-            {
-                put("path", metadata.getPath());
-                put("lastMod", metadata.getModTime());
-                put("offset", recordOffset);
+    public Map<String, Object> buildOffset(FileMetadata metadata, long recordOffset, Map<String, Object> priorOffset) {
+        HashMap<String, Object> result = new HashMap<String, Object>();
+        result.put("path", metadata.getPath());
+        result.put("lastMod", metadata.getModTime());
+        result.put("offset", recordOffset);
+        // The following values aren't needed for resuming reading where we left off.
+        // Rather they are for use in appended metadata (for consumption by a downstream processor).
+        if((recordOffset == 1L) && (Boolean) metadata.getOpt(BULK_OPT)) {
+            result.put("bulkPath", metadata.getPath());
+            if(priorOffset == null) {
+                result.put("priorBulkPath", null);
+            } else {
+                result.put("priorBulkPath", (String) priorOffset.get("bulkPath"));
             }
-        };
+        } else {
+            result.put("bulkPath", (String) priorOffset.get("bulkPath"));
+            result.put("priorBulkPath", (String) priorOffset.get("priorBulkPath"));
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
@@ -1,0 +1,195 @@
+package com.github.mmolimar.kafka.connect.fs.policy;
+
+import com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig;
+import com.github.mmolimar.kafka.connect.fs.file.FileMetadata;
+import com.github.mmolimar.kafka.connect.fs.file.Offset;
+import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class BulkIncrementalPolicy extends AbstractPolicy {
+    public static final String WATCHER_POLICY_PREFIX = FsSourceTaskConfig.POLICY_PREFIX + "watcher.";
+    public static final String WATCHER_POLICY_WATCH_FILEPATH = WATCHER_POLICY_PREFIX + "watch.filepath";
+    public static final String WATCHER_POLICY_WATCH_PATTERNS = WATCHER_POLICY_PREFIX + "watch.patterns";
+
+    private static final String WATCH_KEY_OPT = "watchKey";
+    private static final String BULK_OPT = "bulk";
+    private static final String WATCH_PATTERN_DELINEATOR = ":::";
+    private static final String WATCH_PATTERN_PART_DELINEATOR = ":";
+
+    private File watchFile;
+    private Pattern offsetKeySearchPattern;
+    private String offsetKeyReplacement;
+    private List<WatchedPattern> watchedPatterns;
+    private long lastRead;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    public BulkIncrementalPolicy(FsSourceTaskConfig conf) throws IOException {
+        super(conf);
+    }
+
+    @Override
+    protected void configPolicy(Map<String, Object> customConfigs) {
+        watchFile = new File((String) customConfigs.get(WATCHER_POLICY_WATCH_FILEPATH));
+        watchedPatterns = new ArrayList<>();
+        String watchPatternStr = (String) customConfigs.get(WATCHER_POLICY_WATCH_PATTERNS);
+        if (watchPatternStr == null || watchPatternStr.equals(""))
+            throw new ConnectException("Watch patterns not specified!");
+        String[] watchPatternEntries = watchPatternStr.split(WATCH_PATTERN_DELINEATOR);
+        for (String watchPatternEntry : watchPatternEntries) {
+            String[] watchPatternParts = watchPatternEntry.split(WATCH_PATTERN_PART_DELINEATOR);
+            WatchedPattern watchedPattern;
+            if (watchPatternParts.length == 3)
+                watchedPattern = new WatchedPattern(watchPatternParts[0], Pattern.compile(watchPatternParts[1]), Pattern.compile(watchPatternParts[2]));
+            else if (watchPatternParts.length == 2)
+                watchedPattern = new WatchedPattern(watchPatternParts[0], Pattern.compile(watchPatternParts[1]), null);
+            else
+                throw new ConnectException("Incorrectly specified watch pattern! Should be watchKey:bulkPattern:incrementalPattern");
+            watchedPatterns.add(watchedPattern);
+        }
+    }
+
+    @Override
+    protected void preCheck() {
+        lastRead = watchFile.lastModified();
+    }
+
+    @Override
+    protected boolean shouldInclude(LocatedFileStatus fileStatus, Pattern pattern) {
+        return (super.shouldInclude(fileStatus, pattern) &&
+                fileStatus.getModificationTime() < lastRead);
+    }
+
+    @Override
+    public Iterator<FileMetadata> listFiles(FileSystem fs) throws IOException {
+        Iterator<FileMetadata> iterator = Collections.emptyIterator();
+        for (WatchedPattern pattern : watchedPatterns) {
+            iterator = concat(iterator, buildFileIterator(fs, pattern.bulkFilePattern, new HashMap<String, Object>() {{
+                put(BULK_OPT, true);
+                put(WATCH_KEY_OPT, pattern.key);
+            }}));
+        }
+        for (WatchedPattern pattern : watchedPatterns) {
+            if (pattern.incrementalFilePattern != null)
+                iterator = concat(iterator, buildFileIterator(fs, pattern.incrementalFilePattern, new HashMap<String, Object>() {{
+                    put(BULK_OPT, false);
+                    put(WATCH_KEY_OPT, pattern.key);
+                }}));
+        }
+        return iterator;
+    }
+
+    @Override
+    protected boolean isPolicyCompleted() {
+        return false;
+    }
+
+    @Override
+    public FileReader seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
+        if (offset != null && offset.get("timestamp") != null && offset.get("path") != null) {
+            Long timestamp = ((Long) offset.get("timestamp"));
+            if (timestamp == lastRead && offset.get("offset") != null) {
+                if (metadata.getPath().equals(offset.get("path")))
+                    reader.seek(() -> (Long) offset.get("offset"));
+                else
+                    return null;
+            }
+        }
+        return reader;
+    }
+
+    private String derivePath(FileMetadata metadata) {
+        if (offsetKeySearchPattern == null)
+            return metadata.getPath();
+        return offsetKeySearchPattern.matcher(metadata.getPath()).replaceAll(offsetKeyReplacement);
+    }
+
+    @Override
+    public SchemaAndValue buildKey(FileMetadata metadata) {
+        // build schema
+        SchemaBuilder builder = SchemaBuilder.struct()
+                .name("com.rentpath.filesource.WatchPolicyKey")
+                .optional();
+        builder.field(WATCH_KEY_OPT, Schema.STRING_SCHEMA);
+
+        // build value
+        Map<String, Object> value = new HashMap<String, Object>();
+        value.put(WATCH_KEY_OPT, metadata.getOpt(WATCH_KEY_OPT));
+
+        return new SchemaAndValue(builder.build(), value);
+    }
+
+    @Override
+    public SchemaAndValue buildMetadata(FileMetadata metadata, boolean isLast) {
+        SchemaBuilder metadataBuilder = SchemaBuilder.struct()
+                .name("com.rentpath.filesource.WatcherMetadata")
+                .optional();
+        metadataBuilder.field("path", Schema.STRING_SCHEMA);
+        metadataBuilder.field("last", Schema.BOOLEAN_SCHEMA);
+        metadataBuilder.field("bulk", Schema.BOOLEAN_SCHEMA);
+
+        Map<String, Object> metadataValue = new HashMap<>();
+        metadataValue.put("path", metadata.getPath());
+        metadataValue.put("last", isLast);
+        metadataValue.put("bulk", (Boolean) metadata.getOpt(BULK_OPT));
+
+        return new SchemaAndValue(metadataBuilder.build(), metadataValue);
+    }
+
+    @Override
+    public Map<String, Object> buildOffset(FileMetadata metadata, Map<String, Object> lastOffset, Offset recordOffset, boolean isLast) {
+        Boolean isBulk = (Boolean) (metadata.getOpt(BULK_OPT));
+        Map<String, Object> updated = new HashMap<>();
+        if (!isBulk || (Boolean) (lastOffset.get("bulk"))) {
+            Map<String, Object> last = ((Map<String, Object>) lastOffset.get("paths"));
+            for (String path : last.keySet()) {
+                updated.put(path, last.get(path));
+            }
+        }
+        Map<String, Object> current = new HashMap<>();
+        current.put("offset", recordOffset.getRecordOffset());
+        current.put("finished", isLast);
+        updated.put(metadata.getPath(), current);
+
+        return new HashMap<String, Object>() {
+            {
+                put("bulk", isBulk);
+                put("timestamp", lastRead);
+                put("paths", updated);
+            }
+        };
+    }
+
+    @Override
+    protected boolean shouldOffer(FileMetadata metadata, Map<String, Object> offset) {
+        Map<String, Object> paths = (Map<String, Object>) offset.get("paths");
+        Map<String, Object> pathOffset = (Map<String, Object>) paths.get(metadata.getPath());
+        if ((Boolean) pathOffset.get("finished"))
+            return false;
+        return true;
+    }
+
+    class WatchedPattern {
+        String key;
+        Pattern bulkFilePattern;
+        Pattern incrementalFilePattern;
+
+        WatchedPattern(String key, Pattern bulkFilePattern, Pattern incrementalFilePattern) {
+            this.key = key;
+            this.bulkFilePattern = bulkFilePattern;
+            this.incrementalFilePattern = incrementalFilePattern;
+        }
+    }
+}

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/HdfsFileWatcherPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/HdfsFileWatcherPolicy.java
@@ -145,8 +145,8 @@ public class HdfsFileWatcherPolicy extends AbstractPolicy {
             RemoteIterator<LocatedFileStatus> it = fs.listFiles(filePath, false);
             while (it.hasNext()) {
                 LocatedFileStatus status = it.next();
-                if (!status.isFile() || !fileRegexp.matcher(status.getPath().getName()).find()) continue;
-                fileQueue.offer(toMetadata(status));
+                if (!status.isFile() || !filePattern.matcher(status.getPath().getName()).find()) continue;
+                fileQueue.offer(toMetadata(status, null));
             }
         }
     }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -25,7 +25,8 @@ public interface Policy extends Closeable {
 
     void interrupt();
 
+    Map<String,Object> buildPartition(FileMetadata metadata);
+    Map<String,Object> buildOffset(FileMetadata metadata, long recordOffset);
     SchemaAndValue buildKey(FileMetadata metadata);
-    Map<String,Object> buildOffset(FileMetadata metadata, Map<String, Object> lastOffset, Offset recordOffset, boolean isLast);
-    SchemaAndValue buildMetadata(FileMetadata metadata, boolean isLast);
+    SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast);
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -1,23 +1,31 @@
 package com.github.mmolimar.kafka.connect.fs.policy;
 
 import com.github.mmolimar.kafka.connect.fs.file.FileMetadata;
+import com.github.mmolimar.kafka.connect.fs.file.Offset;
 import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public interface Policy extends Closeable {
 
     Iterator<FileMetadata> execute() throws IOException;
 
-    FileReader offer(FileMetadata metadata, OffsetStorageReader offsetStorageReader) throws IOException;
+    FileReader offer(FileMetadata metadata, Map<String, Object> lastOffset) throws IOException;
 
     boolean hasEnded();
 
     List<String> getURIs();
 
     void interrupt();
+
+    SchemaAndValue buildKey(FileMetadata metadata);
+    Map<String,Object> buildOffset(FileMetadata metadata, Map<String, Object> lastOffset, Offset recordOffset, boolean isLast);
+    SchemaAndValue buildMetadata(FileMetadata metadata, boolean isLast);
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -26,7 +26,7 @@ public interface Policy extends Closeable {
     void interrupt();
 
     Map<String,Object> buildPartition(FileMetadata metadata);
-    Map<String,Object> buildOffset(FileMetadata metadata, long recordOffset);
+    Map<String,Object> buildOffset(FileMetadata metadata, long recordOffset, Map<String,Object> priorOffset);
     SchemaAndValue buildKey(FileMetadata metadata);
-    SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast);
+    SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset);
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/util/ReflectionUtils.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/util/ReflectionUtils.java
@@ -2,6 +2,7 @@ package com.github.mmolimar.kafka.connect.fs.util;
 
 import com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig;
 import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
+import com.github.mmolimar.kafka.connect.fs.file.reader.schema.SchemaReader;
 import com.github.mmolimar.kafka.connect.fs.policy.Policy;
 import org.apache.commons.lang.reflect.ConstructorUtils;
 import org.apache.hadoop.fs.FileSystem;
@@ -21,6 +22,10 @@ public class ReflectionUtils {
 
     public static Policy makePolicy(Class<? extends Policy> clazz, FsSourceTaskConfig conf) throws Throwable {
         return make(clazz, conf);
+    }
+
+    public static SchemaReader makeSchemaReader(FileSystem fs, Class<? extends SchemaReader> clazz, Map<String, Object> config) throws Throwable {
+        return make(clazz, fs, config);
     }
 
     private static <T> T make(Class<T> clazz, Object... args) throws Throwable {

--- a/src/main/java/com/rentpath/kafka/connect/connectors/filesystem/policies/TriggeredPolicy.java
+++ b/src/main/java/com/rentpath/kafka/connect/connectors/filesystem/policies/TriggeredPolicy.java
@@ -1,0 +1,67 @@
+package com.rentpath.kafka.connect.connectors.filesystem.policies;
+
+import com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig;
+import com.github.mmolimar.kafka.connect.fs.policy.AbstractPolicy;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
+
+public class TriggeredPolicy extends AbstractPolicy {
+    public static final String TRIGGERED_POLICY_PREFIX = FsSourceTaskConfig.POLICY_PREFIX + "triggered.";
+    public static final String CONSUMER_BOOTSTRAP_SERVERS = TRIGGERED_POLICY_PREFIX + "bootstrap.servers";
+    public static final String CONSUMER_GROUP_ID_PREFIX = TRIGGERED_POLICY_PREFIX + "group.id.prefix";
+    public static final String CONSUMER_KEY_DESERIALIZER_CLASS = TRIGGERED_POLICY_PREFIX + "key.deserializer.class";
+    public static final String CONSUMER_VALUE_DESERIALIZER_CLASS = TRIGGERED_POLICY_PREFIX + "value.deserializer.class";
+    public static final String CONSUMER_TOPIC = TRIGGERED_POLICY_PREFIX + "trigger.topic";
+    public static final String CONSUMER_POLL_DURATION_MS = TRIGGERED_POLICY_PREFIX + "poll.duration.ms";
+
+    private Consumer<Void, String> consumer;
+    private String fileRegexp;
+    private Duration pollDuration;
+
+    public TriggeredPolicy(FsSourceTaskConfig conf) throws IOException {
+        super(conf);
+        fileRegexp = conf.getString(FsSourceTaskConfig.POLICY_REGEXP);
+    }
+
+    @Override
+    protected void configPolicy(Map<String, Object> conf) {
+        Properties consumerProperties = new Properties();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, conf.get(CONSUMER_BOOTSTRAP_SERVERS));
+        consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, ((String) conf.get(CONSUMER_GROUP_ID_PREFIX)) + "--" + fileRegexp);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, conf.get(CONSUMER_KEY_DESERIALIZER_CLASS));
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, conf.get(CONSUMER_VALUE_DESERIALIZER_CLASS));
+        consumerProperties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+        consumerProperties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        try {
+            pollDuration = Duration.ofMillis((Long.parseLong((String) conf.get(CONSUMER_POLL_DURATION_MS))));
+        } catch (NumberFormatException e) {
+            throw new ConfigException(CONSUMER_POLL_DURATION_MS + " property is required and must be a number(long). Got: " +
+                    conf.get(CONSUMER_POLL_DURATION_MS));
+        }
+        consumer = new KafkaConsumer<Void, String>(consumerProperties);
+        consumer.assign(Collections.singletonList(new TopicPartition((String) conf.get(CONSUMER_TOPIC), 1)));
+    }
+
+    @Override
+    protected boolean isPolicyCompleted() {
+        return false;
+    }
+
+    @Override
+    protected void preCheck() {
+        while (true) {
+            ConsumerRecords<Void, String> records = consumer.poll(pollDuration);
+            if (!records.isEmpty()) {
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReader.java
+++ b/src/main/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReader.java
@@ -1,0 +1,87 @@
+package com.rentpath.kafka.connect.connectors.filesystem.readers;
+
+import com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig;
+import com.github.mmolimar.kafka.connect.fs.file.Offset;
+import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
+import com.github.mmolimar.kafka.connect.fs.file.reader.TextFileReader;
+import com.github.mmolimar.kafka.connect.fs.file.reader.schema.SchemaReader;
+import com.github.mmolimar.kafka.connect.fs.policy.Policy;
+import com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig.FILE_READER_PREFIX;
+
+public class JsonFileReader implements FileReader {
+    public static final String SCHEMA_READER_CLASS = FILE_READER_PREFIX + "schema.reader.class";
+
+    private JsonConverter converter;
+    private TextFileReader reader;
+    private String schema;
+    private SchemaReader schemaReader;
+
+    public JsonFileReader(FileSystem fs, Path filePath, Map<String, Object> config) throws Throwable {
+        reader = new TextFileReader(fs, filePath, config);
+        converter = new JsonConverter();
+
+        try {
+            String klazz = (String) config.get(SCHEMA_READER_CLASS);
+            Class<SchemaReader> schemaReaderClass = (Class<SchemaReader>) Class.forName(klazz);
+            if (!SchemaReader.class.isAssignableFrom(schemaReaderClass))
+                throw new ConfigException("Schema Reader class " + schemaReaderClass + " does not implement interface " + SchemaReader.class);
+            schemaReader = ReflectionUtils.makeSchemaReader(fs, schemaReaderClass, config);
+            schema = schemaReader.readSchema();
+        } catch (ClassNotFoundException e) {
+            throw new ConfigException(SCHEMA_READER_CLASS + " class not found. Got: " +
+                    config.get(SCHEMA_READER_CLASS));
+        }
+
+        Map<String, Object> converterConf = new HashMap<>();
+        converterConf.put(ConverterConfig.TYPE_CONFIG, "value");
+        converter.configure(converterConf);
+    }
+
+    @Override
+    public Path getFilePath() {
+        return reader.getFilePath();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return reader.hasNext();
+    }
+
+    @Override
+    public SchemaAndValue next() {
+        SchemaAndValue textSNV = reader.next();
+        String jsonValue = ((Struct) textSNV.value()).getString(reader.getSchema().fields().get(0).name());
+        String wrappedJsonValue = String.format("{\"schema\":%s,\"payload\":%s}", schema, jsonValue);
+        return converter.toConnectData(null, wrappedJsonValue.getBytes());
+    }
+
+    @Override
+    public void seek(Offset offset) {
+        reader.seek(offset);
+    }
+
+    @Override
+    public Offset currentOffset() {
+        return reader.currentOffset();
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+}

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/FileReaderTestBase.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/FileReaderTestBase.java
@@ -4,7 +4,7 @@ import com.github.mmolimar.kafka.connect.fs.file.Offset;
 import com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -91,8 +91,7 @@ public abstract class FileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
-            checkData(record, recordCount);
+            checkData(reader.next(), recordCount);
             recordCount++;
         }
         assertEquals("The number of records in the file does not match", NUM_RECORDS, recordCount);
@@ -148,7 +147,7 @@ public abstract class FileReaderTestBase {
 
     protected abstract Offset getOffset(long offset);
 
-    protected abstract void checkData(Struct record, long index);
+    protected abstract void checkData(SchemaAndValue record, long index);
 
     protected abstract String getFileExtension();
 

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/AvroFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/AvroFileReaderTest.java
@@ -12,6 +12,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -100,10 +101,11 @@ public class AvroFileReaderTest extends HdfsFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue((Integer) record.get(FIELD_INDEX) == index);
-        assertTrue(record.get(FIELD_NAME).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_SURNAME).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue((Integer) recordStruct.get(FIELD_INDEX) == index);
+        assertTrue(recordStruct.get(FIELD_NAME).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_SURNAME).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/DelimitedTextFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/DelimitedTextFileReaderTest.java
@@ -6,6 +6,7 @@ import com.github.mmolimar.kafka.connect.fs.file.reader.DelimitedTextFileReader;
 import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -94,8 +95,7 @@ public class DelimitedTextFileReaderTest extends HdfsFileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
-            checkData(record, recordCount);
+            checkData(reader.next(), recordCount);
             recordCount++;
         }
         assertEquals("The number of records in the file does not match", NUM_RECORDS, recordCount);
@@ -123,7 +123,7 @@ public class DelimitedTextFileReaderTest extends HdfsFileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
+            Struct record = (Struct) reader.next().value();
             assertTrue(record.get(FIELD_COLUMN1).equals("dummy"));
             assertTrue(record.get(FIELD_COLUMN2).equals("custom_value"));
             assertTrue(record.get(FIELD_COLUMN3).equals("custom_value"));
@@ -196,11 +196,12 @@ public class DelimitedTextFileReaderTest extends HdfsFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue(record.get(FIELD_COLUMN1).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_COLUMN2).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_COLUMN3).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_COLUMN4).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue(recordStruct.get(FIELD_COLUMN1).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_COLUMN2).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_COLUMN3).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_COLUMN4).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/ParquetFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/ParquetFileReaderTest.java
@@ -12,6 +12,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.parquet.avro.AvroParquetWriter;
@@ -91,7 +92,7 @@ public class ParquetFileReaderTest extends HdfsFileReaderTestBase {
         }};
         reader = getReader(FileSystem.newInstance(fsUri, new Configuration()), dataFile, cfg);
         while (reader.hasNext()) {
-            Struct record = reader.next();
+            Struct record = (Struct) reader.next().value();
             assertNotNull(record.schema().field(FIELD_INDEX));
             assertNotNull(record.schema().field(FIELD_NAME));
             assertNull(record.schema().field(FIELD_SURNAME));
@@ -137,10 +138,11 @@ public class ParquetFileReaderTest extends HdfsFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue((Integer) record.get(FIELD_INDEX) == index);
-        assertTrue(record.get(FIELD_NAME).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_SURNAME).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue((Integer) recordStruct.get(FIELD_INDEX) == index);
+        assertTrue(recordStruct.get(FIELD_NAME).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_SURNAME).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/SequenceFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/SequenceFileReaderTest.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -81,8 +82,7 @@ public class SequenceFileReaderTest extends HdfsFileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
-            checkData(SequenceFileReader.FIELD_NAME_KEY_DEFAULT, SequenceFileReader.FIELD_NAME_VALUE_DEFAULT, record, recordCount);
+            checkData(SequenceFileReader.FIELD_NAME_KEY_DEFAULT, SequenceFileReader.FIELD_NAME_VALUE_DEFAULT, reader.next(), recordCount);
             recordCount++;
         }
         assertEquals("The number of records in the file does not match", NUM_RECORDS, recordCount);
@@ -94,13 +94,14 @@ public class SequenceFileReaderTest extends HdfsFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
+    protected void checkData(SchemaAndValue record, long index) {
         checkData(FIELD_NAME_KEY, FIELD_NAME_VALUE, record, index);
     }
 
-    private void checkData(String keyFieldName, String valueFieldName, Struct record, long index) {
-        assertTrue((Integer) record.get(keyFieldName) == index);
-        assertTrue(record.get(valueFieldName).toString().startsWith(index + "_"));
+    private void checkData(String keyFieldName, String valueFieldName, SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue((Integer) recordStruct.get(keyFieldName) == index);
+        assertTrue(recordStruct.get(valueFieldName).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/TextFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/TextFileReaderTest.java
@@ -4,6 +4,7 @@ import com.github.mmolimar.kafka.connect.fs.file.Offset;
 import com.github.mmolimar.kafka.connect.fs.file.reader.AgnosticFileReader;
 import com.github.mmolimar.kafka.connect.fs.file.reader.TextFileReader;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -90,8 +91,8 @@ public class TextFileReaderTest extends HdfsFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue(record.get(FIELD_NAME_VALUE).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        assertTrue(((Struct) record.value()).get(FIELD_NAME_VALUE).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/AvroFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/AvroFileReaderTest.java
@@ -12,6 +12,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -105,10 +106,11 @@ public class AvroFileReaderTest extends LocalFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue((Integer) record.get(FIELD_INDEX) == index);
-        assertTrue(record.get(FIELD_NAME).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_SURNAME).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue((Integer) recordStruct.get(FIELD_INDEX) == index);
+        assertTrue(recordStruct.get(FIELD_NAME).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_SURNAME).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/DelimitedTextFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/DelimitedTextFileReaderTest.java
@@ -6,6 +6,7 @@ import com.github.mmolimar.kafka.connect.fs.file.reader.DelimitedTextFileReader;
 import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -99,8 +100,7 @@ public class DelimitedTextFileReaderTest extends LocalFileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
-            checkData(record, recordCount);
+            checkData(reader.next(), recordCount);
             recordCount++;
         }
         assertEquals("The number of records in the file does not match", NUM_RECORDS, recordCount);
@@ -129,7 +129,7 @@ public class DelimitedTextFileReaderTest extends LocalFileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
+            Struct record = (Struct)reader.next().value();
             assertTrue(record.get(FIELD_COLUMN1).equals("dummy"));
             assertTrue(record.get(FIELD_COLUMN2).equals("custom_value"));
             assertTrue(record.get(FIELD_COLUMN3).equals("custom_value"));
@@ -205,11 +205,12 @@ public class DelimitedTextFileReaderTest extends LocalFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue(record.get(FIELD_COLUMN1).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_COLUMN2).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_COLUMN3).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_COLUMN4).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue(recordStruct.get(FIELD_COLUMN1).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_COLUMN2).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_COLUMN3).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_COLUMN4).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/LineSkippingTextFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/LineSkippingTextFileReaderTest.java
@@ -21,7 +21,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertTrue;
 
-public class TextFileReaderTest extends LocalFileReaderTestBase {
+public class LineSkippingTextFileReaderTest extends LocalFileReaderTestBase {
 
     private static final String FIELD_NAME_VALUE = "custom_field_name";
     private static final String FILE_EXTENSION = "txt";
@@ -32,6 +32,7 @@ public class TextFileReaderTest extends LocalFileReaderTestBase {
         dataFile = createDataFile();
         readerConfig = new HashMap<String, Object>() {{
             put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
+            put(TextFileReader.FILE_READER_LINES_SKIP, "2");
         }};
     }
 
@@ -42,6 +43,7 @@ public class TextFileReaderTest extends LocalFileReaderTestBase {
             IntStream.range(0, NUM_RECORDS).forEach(index -> {
                 String value = String.format("%d_%s", index, UUID.randomUUID());
                 try {
+                    writer.append("thisisgarbage\n");
                     writer.append(value + "\n");
                     OFFSETS_BY_INDEX.put(index, Long.valueOf(index++));
                 } catch (IOException ioe) {
@@ -71,6 +73,7 @@ public class TextFileReaderTest extends LocalFileReaderTestBase {
         Map<String, Object> cfg = new HashMap<String, Object>() {{
             put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
             put(TextFileReader.FILE_READER_TEXT_ENCODING, "Cp1252");
+            put(TextFileReader.FILE_READER_LINES_SKIP, "2");
         }};
         reader = getReader(fs, dataFile, cfg);
         readAllData();

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/ParquetFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/ParquetFileReaderTest.java
@@ -12,6 +12,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.parquet.avro.AvroParquetWriter;
@@ -95,7 +96,7 @@ public class ParquetFileReaderTest extends LocalFileReaderTestBase {
         }};
         reader = getReader(FileSystem.newInstance(fsUri, new Configuration()), dataFile, cfg);
         while (reader.hasNext()) {
-            Struct record = reader.next();
+            Struct record = (Struct)reader.next().value();
             assertNotNull(record.schema().field(FIELD_INDEX));
             assertNotNull(record.schema().field(FIELD_NAME));
             assertNull(record.schema().field(FIELD_SURNAME));
@@ -144,10 +145,11 @@ public class ParquetFileReaderTest extends LocalFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
-        assertTrue((Integer) record.get(FIELD_INDEX) == index);
-        assertTrue(record.get(FIELD_NAME).toString().startsWith(index + "_"));
-        assertTrue(record.get(FIELD_SURNAME).toString().startsWith(index + "_"));
+    protected void checkData(SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue((Integer) recordStruct.get(FIELD_INDEX) == index);
+        assertTrue(recordStruct.get(FIELD_NAME).toString().startsWith(index + "_"));
+        assertTrue(recordStruct.get(FIELD_SURNAME).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/SequenceFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/SequenceFileReaderTest.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -84,8 +85,7 @@ public class SequenceFileReaderTest extends LocalFileReaderTestBase {
 
         int recordCount = 0;
         while (reader.hasNext()) {
-            Struct record = reader.next();
-            checkData(SequenceFileReader.FIELD_NAME_KEY_DEFAULT, SequenceFileReader.FIELD_NAME_VALUE_DEFAULT, record, recordCount);
+            checkData(SequenceFileReader.FIELD_NAME_KEY_DEFAULT, SequenceFileReader.FIELD_NAME_VALUE_DEFAULT, reader.next(), recordCount);
             recordCount++;
         }
         assertEquals("The number of records in the file does not match", NUM_RECORDS, recordCount);
@@ -97,13 +97,14 @@ public class SequenceFileReaderTest extends LocalFileReaderTestBase {
     }
 
     @Override
-    protected void checkData(Struct record, long index) {
+    protected void checkData(SchemaAndValue record, long index) {
         checkData(FIELD_NAME_KEY, FIELD_NAME_VALUE, record, index);
     }
 
-    private void checkData(String keyFieldName, String valueFieldName, Struct record, long index) {
-        assertTrue((Integer) record.get(keyFieldName) == index);
-        assertTrue(record.get(valueFieldName).toString().startsWith(index + "_"));
+    private void checkData(String keyFieldName, String valueFieldName, SchemaAndValue record, long index) {
+        Struct recordStruct = (Struct) record.value();
+        assertTrue((Integer) recordStruct.get(keyFieldName) == index);
+        assertTrue(recordStruct.get(valueFieldName).toString().startsWith(index + "_"));
     }
 
     @Override

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/HdfsFileWatcherPolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/HdfsFileWatcherPolicyTest.java
@@ -36,7 +36,7 @@ public class HdfsFileWatcherPolicyTest extends HdfsPolicyTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, HdfsFileWatcherPolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "[0-9]*\\.txt$");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
         }};

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/HdfsFileWatcherPolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/HdfsFileWatcherPolicyTest.java
@@ -36,7 +36,7 @@ public class HdfsFileWatcherPolicyTest extends HdfsPolicyTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, HdfsFileWatcherPolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "^[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
         }};

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/SimplePolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/SimplePolicyTest.java
@@ -31,7 +31,7 @@ public class SimplePolicyTest extends HdfsPolicyTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, SimplePolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "^[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
         }};

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/SleepyPolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/hdfs/SleepyPolicyTest.java
@@ -38,7 +38,7 @@ public class SleepyPolicyTest extends HdfsPolicyTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, SleepyPolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "^[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
             put(SleepyPolicy.SLEEPY_POLICY_SLEEP_MS, "100");

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/BulkIncrementalPolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/BulkIncrementalPolicyTest.java
@@ -41,7 +41,7 @@ public class BulkIncrementalPolicyTest extends LocalPolicyTestBase {
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
             put(BulkIncrementalPolicy.WATCHER_POLICY_WATCH_FILEPATH, watchFile.getAbsolutePath());
-            put(BulkIncrementalPolicy.WATCHER_POLICY_WATCH_PATTERNS, "someKey:^[0-9]*\\.txt$");
+            put(BulkIncrementalPolicy.WATCHER_POLICY_WATCH_PATTERNS, "someKey:\\/[0-9]*\\.txt$");
         }};
 
         taskConfig = new FsSourceTaskConfig(cfg);

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/BulkIncrementalPolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/BulkIncrementalPolicyTest.java
@@ -1,0 +1,66 @@
+package com.github.mmolimar.kafka.connect.fs.policy.local;
+
+import com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig;
+import com.github.mmolimar.kafka.connect.fs.file.reader.TextFileReader;
+import com.github.mmolimar.kafka.connect.fs.policy.BulkIncrementalPolicy;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.errors.IllegalWorkerStateException;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class BulkIncrementalPolicyTest extends LocalPolicyTestBase {
+    @Override
+    public void initPolicy() throws Throwable {
+        File watchFile = new File(localDir.toFile(), "watchfile");
+        watchFile.createNewFile();
+        watchFile.setLastModified(Long.MAX_VALUE);
+        super.initPolicy();
+    }
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        directories = new ArrayList<Path>() {{
+            add(new Path(fsUri.toString(), UUID.randomUUID().toString()));
+            add(new Path(fsUri.toString(), UUID.randomUUID().toString()));
+        }};
+        for (Path dir : directories) {
+            fs.mkdirs(dir);
+        }
+        File watchFile = new File(localDir.toFile(), "watchfile");
+
+        Map<String, String> cfg = new HashMap<String, String>() {{
+            String uris[] = directories.stream().map(dir -> dir.toString())
+                    .toArray(size -> new String[size]);
+            put(FsSourceTaskConfig.FS_URIS, String.join(",", uris));
+            put(FsSourceTaskConfig.TOPIC, "topic_test");
+            put(FsSourceTaskConfig.POLICY_CLASS, BulkIncrementalPolicy.class.getName());
+            put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
+            put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
+            put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
+            put(BulkIncrementalPolicy.WATCHER_POLICY_WATCH_FILEPATH, watchFile.getAbsolutePath());
+            put(BulkIncrementalPolicy.WATCHER_POLICY_WATCH_PATTERNS, "someKey:^[0-9]*\\.txt$");
+        }};
+
+        taskConfig = new FsSourceTaskConfig(cfg);
+    }
+
+    @Override
+    public void hasEnded() throws IOException {
+    }
+
+    @Override
+    public void execPolicyAlreadyEnded() throws IOException {
+        throw new IllegalWorkerStateException("Dummy Exception");
+    }
+
+    @Override
+    public void cleanDirs() throws IOException {
+        File watchFile = new File(localDir.toFile(), "watchfile");
+        if (watchFile.exists())
+            watchFile.delete();
+        super.cleanDirs();
+    }
+}

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/LocalPolicyTestBase.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/LocalPolicyTestBase.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
 
 public abstract class LocalPolicyTestBase extends PolicyTestBase {
 
-    private static Path localDir;
+    protected static Path localDir;
 
     @BeforeClass
     public static void initFs() throws IOException {

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/SimplePolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/SimplePolicyTest.java
@@ -31,7 +31,7 @@ public class SimplePolicyTest extends LocalPolicyTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, SimplePolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "^[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
         }};

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/SleepyPolicyTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/policy/local/SleepyPolicyTest.java
@@ -38,7 +38,7 @@ public class SleepyPolicyTest extends LocalPolicyTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, SleepyPolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "^[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "dfs.data.dir", "test");
             put(FsSourceTaskConfig.POLICY_PREFIX_FS + "fs.default.name", "test");
             put(SleepyPolicy.SLEEPY_POLICY_SLEEP_MS, "100");

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/task/FsSourceTaskTestBase.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/task/FsSourceTaskTestBase.java
@@ -60,7 +60,7 @@ public abstract class FsSourceTaskTestBase {
             put(FsSourceTaskConfig.TOPIC, "topic_test");
             put(FsSourceTaskConfig.POLICY_CLASS, SimplePolicy.class.getName());
             put(FsSourceTaskConfig.FILE_READER_CLASS, TextFileReader.class.getName());
-            put(FsSourceTaskConfig.POLICY_REGEXP, "^[0-9]*\\.txt$");
+            put(FsSourceTaskConfig.POLICY_REGEXP, "\\/[0-9]*\\.txt$");
         }};
 
         //Mock initialization

--- a/src/test/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReaderTest.java
+++ b/src/test/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReaderTest.java
@@ -29,16 +29,14 @@ import static org.junit.Assert.assertTrue;
 
 public class JsonFileReaderTest extends LocalFileReaderTestBase {
     private static final String FILE_EXTENSION = "json";
-    private static Path schemaFile;
 
     @BeforeClass
     public static void setUp() throws IOException {
         readerClass = JsonFileReader.class;
         dataFile = createDataFile();
-        schemaFile = createSchemaFile();
         readerConfig = new HashMap<String, Object>() {{
             put(JsonFileReader.SCHEMA_READER_CLASS, "com.github.mmolimar.kafka.connect.fs.file.reader.schema.FileSchemaReader");
-            put(FileSchemaReader.PATH, schemaFile);
+            put(FileSchemaReader.PATH, createSchemaFile().toString());
         }};
     }
 

--- a/src/test/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReaderTest.java
+++ b/src/test/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReaderTest.java
@@ -1,11 +1,17 @@
-package com.github.mmolimar.kafka.connect.fs.file.reader.local;
+package com.rentpath.kafka.connect.connectors.filesystem.readers;
 
 import com.github.mmolimar.kafka.connect.fs.file.Offset;
-import com.github.mmolimar.kafka.connect.fs.file.reader.AgnosticFileReader;
+import com.github.mmolimar.kafka.connect.fs.file.reader.schema.FileSchemaReader;
 import com.github.mmolimar.kafka.connect.fs.file.reader.TextFileReader;
+import com.github.mmolimar.kafka.connect.fs.file.reader.local.LocalFileReaderTestBase;
+import com.github.mmolimar.kafka.connect.fs.file.reader.schema.GithubSchemaReader;
+import io.confluent.connect.avro.AvroConverter;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.storage.Converter;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -21,26 +27,41 @@ import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertTrue;
 
-public class TextFileReaderTest extends LocalFileReaderTestBase {
-
-    private static final String FIELD_NAME_VALUE = "custom_field_name";
-    private static final String FILE_EXTENSION = "txt";
+public class JsonFileReaderTest extends LocalFileReaderTestBase {
+    private static final String FILE_EXTENSION = "json";
+    private static Path schemaFile;
 
     @BeforeClass
     public static void setUp() throws IOException {
-        readerClass = AgnosticFileReader.class;
+        readerClass = JsonFileReader.class;
         dataFile = createDataFile();
+        schemaFile = createSchemaFile();
         readerConfig = new HashMap<String, Object>() {{
-            put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
+            put(JsonFileReader.SCHEMA_READER_CLASS, "com.github.mmolimar.kafka.connect.fs.file.reader.schema.FileSchemaReader");
+            put(FileSchemaReader.PATH, schemaFile);
         }};
+    }
+
+    private static Path createSchemaFile() throws IOException {
+        File schemaFile = File.createTempFile("test-schema-", "." + FILE_EXTENSION);
+        try (FileWriter writer = new FileWriter(schemaFile)) {
+            String value = String.format("{\"type\":\"struct\", \"fields\":[{\"field\":\"index\",\"type\":\"int64\"},{\"field\":\"value\",\"type\":\"string\"}]}");
+            try {
+                writer.append(value);
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
+        Path path = new Path(new Path(fsUri), schemaFile.getName());
+        fs.moveFromLocalFile(new Path(schemaFile.getAbsolutePath()), path);
+        return path;
     }
 
     private static Path createDataFile() throws IOException {
         File txtFile = File.createTempFile("test-", "." + FILE_EXTENSION);
         try (FileWriter writer = new FileWriter(txtFile)) {
-
             IntStream.range(0, NUM_RECORDS).forEach(index -> {
-                String value = String.format("%d_%s", index, UUID.randomUUID());
+                String value = String.format("{\"index\":%d, \"value\":\"%s\"}", index, UUID.randomUUID());
                 try {
                     writer.append(value + "\n");
                     OFFSETS_BY_INDEX.put(index, Long.valueOf(index++));
@@ -54,35 +75,16 @@ public class TextFileReaderTest extends LocalFileReaderTestBase {
         return path;
     }
 
-    @Ignore(value = "This test does not apply for txt files")
+    @Ignore(value = "This test does not apply for json files")
     @Test(expected = IOException.class)
     public void emptyFile() throws Throwable {
         super.emptyFile();
     }
 
-    @Ignore(value = "This test does not apply for txt files")
+    @Ignore(value = "This test does not apply for json files")
     @Test(expected = IOException.class)
     public void invalidFileFormat() throws Throwable {
         super.invalidFileFormat();
-    }
-
-    @Test
-    public void validFileEncoding() throws Throwable {
-        Map<String, Object> cfg = new HashMap<String, Object>() {{
-            put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
-            put(TextFileReader.FILE_READER_TEXT_ENCODING, "Cp1252");
-        }};
-        reader = getReader(fs, dataFile, cfg);
-        readAllData();
-    }
-
-    @Test(expected = UnsupportedCharsetException.class)
-    public void invalidFileEncoding() throws Throwable {
-        Map<String, Object> cfg = new HashMap<String, Object>() {{
-            put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
-            put(TextFileReader.FILE_READER_TEXT_ENCODING, "invalid_charset");
-        }};
-        getReader(fs, dataFile, cfg);
     }
 
     @Override
@@ -92,7 +94,8 @@ public class TextFileReaderTest extends LocalFileReaderTestBase {
 
     @Override
     protected void checkData(SchemaAndValue record, long index) {
-        assertTrue(((Struct) record.value()).get(FIELD_NAME_VALUE).toString().startsWith(index + "_"));
+        Struct recordMap = (Struct) record.value();
+        assertTrue(recordMap.getInt64("index").equals(index));
     }
 
     @Override


### PR DESCRIPTION
This adds a few features to the extant TextFileReader, namely:
- Ability to designate a line skip modulus (i.e. "only read every 3rd line")
- Extensibility of the TextFileReader and Adapters for additional implementations
- A new JsonFileReader class and adapter to parse (using the Confluent Json Converter) the output text as JSON prior to delivering to Connect for production to a topic