### PR TITLE
Address potential for stale file error during seek

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -132,6 +132,7 @@ public class FsSourceTask extends SourceTask {
                 Map<String, Object> partition = policy.buildOffsetPartition(metadata);
                 Map<String, Object> lastOffset = getOffset(partition);
                 try (FileReader reader = policy.offer(metadata, lastOffset)) {
+                    policy.seekReader(metadata, lastOffset, reader);
                     if (reader != null) {
                         log.info("Processing records for file {}", metadata);
                         while (reader.hasNext() && (maxBatchSize == 0 || count < maxBatchSize)) {

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -218,11 +218,11 @@ public abstract class AbstractPolicy implements Policy {
         return metadata;
     }
 
-    public FileReader seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
+    @Override
+    public void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
         if (offset != null && offset.get("offset") != null) {
             reader.seek(() -> (Long) offset.get("offset"));
         }
-        return reader;
     }
 
     protected boolean shouldOffer(FileMetadata metadata, Map<String, Object> offset) {
@@ -245,8 +245,7 @@ public abstract class AbstractPolicy implements Policy {
         } catch (Throwable t) {
             throw new ConnectException("An error has occurred when creating reader for file: " + metadata.getPath(), t);
         }
-
-        return seekReader(metadata, lastOffset, reader);
+        return reader;
     }
 
     Iterator<FileMetadata> concat(final Iterator<FileMetadata> it1,

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
@@ -120,11 +120,10 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
     }
 
     @Override
-    public FileReader seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
+    public void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
         if (offset != null && offset.get(OFFSET_OPT) != null && metadata.getPath().equals(offset.get(PATH_OPT))) {
             reader.seek(() -> (Long) offset.get(OFFSET_OPT));
         }
-        return reader;
     }
 
     @Override

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -27,4 +27,5 @@ public interface Policy extends Closeable {
     SchemaAndValue buildKey(FileMetadata metadata, SchemaAndValue snvValue, Map<String, Object> offset);
     SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset);
     FileMetadata extractExemplar(List<FileMetadata> batchFileMetadata);
+    void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader);
 }


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-2010)

This pushes responsibility for performing the file seek into the task
itself as opposed to a part of the reader factory; doing so ensures that
the seek attempt occurs within the existing try/catch block as opposed
to being counted as part of the resource instantiation, which is *not*
accounted part of said block.