### PR TITLE
Make IOException/ConnectExceptions explicit

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -150,8 +150,10 @@ public class FsSourceTask extends SourceTask {
                             count++;
                         }
                     }
-                } catch (ConnectException | IOException e) {
+                } catch (ConnectException e) {
                     //when an exception happens reading a file, the connector continues
+                    log.error("Possible error reading file from FS: " + metadata.getPath() + ". Keep going...", e);
+                } catch (IOException e) {
                     log.error("Error reading file from FS: " + metadata.getPath() + ". Keep going...", e);
                 }
             }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AgnosticFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AgnosticFileReader.java
@@ -7,6 +7,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.data.SchemaAndValue;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,7 @@ public class AgnosticFileReader extends AbstractFileReader<AgnosticFileReader.Ag
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException, IOException, IllegalArgumentException {
         reader.seek(offset);
     }
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AvroFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AvroFileReader.java
@@ -63,7 +63,7 @@ public class AvroFileReader extends AbstractFileReader<GenericRecord> {
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException {
         try {
             reader.sync(offset.getRecordOffset());
             this.offset.setOffset(reader.previousSync() - 15);

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/DelimitedTextFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/DelimitedTextFileReader.java
@@ -7,6 +7,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class DelimitedTextFileReader extends AbstractFileReader<DelimitedTextFil
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException, IllegalArgumentException {
         inner.seek(offset);
         this.offset.setOffset(inner.currentOffset().getRecordOffset());
     }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/FileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/FileReader.java
@@ -3,8 +3,10 @@ package com.github.mmolimar.kafka.connect.fs.file.reader;
 import com.github.mmolimar.kafka.connect.fs.file.Offset;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Iterator;
 
 public interface FileReader extends Iterator<SchemaAndValue>, Closeable {
@@ -15,7 +17,7 @@ public interface FileReader extends Iterator<SchemaAndValue>, Closeable {
 
     SchemaAndValue next();
 
-    void seek(Offset offset);
+    void seek(Offset offset) throws ConnectException, IOException, IllegalArgumentException;
 
     Offset currentOffset();
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
@@ -107,7 +107,7 @@ public class ParquetFileReader extends AbstractFileReader<GenericRecord> {
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException, IllegalArgumentException {
         if (closed) {
             throw new ConnectException("Stream is closed!");
         }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/SequenceFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/SequenceFileReader.java
@@ -125,7 +125,7 @@ public class SequenceFileReader extends AbstractFileReader<SequenceFileReader.Se
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException {
         if (offset.getRecordOffset() < 0) {
             throw new IllegalArgumentException("Record offset must be greater than 0");
         }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/TextFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/TextFileReader.java
@@ -144,7 +144,7 @@ public class TextFileReader extends AbstractFileReader<TextFileReader.TextRecord
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException, IllegalArgumentException {
         if (offset.getRecordOffset() < 0) {
             throw new IllegalArgumentException("Record offset must be greater than 0");
         }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -219,7 +219,7 @@ public abstract class AbstractPolicy implements Policy {
     }
 
     @Override
-    public void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
+    public void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) throws ConnectException, IOException, IllegalArgumentException {
         if (offset != null && offset.get("offset") != null) {
             reader.seek(() -> (Long) offset.get("offset"));
         }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
@@ -120,7 +120,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
     }
 
     @Override
-    public void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) {
+    public void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) throws ConnectException, IOException, IllegalArgumentException {
         if (offset != null && offset.get(OFFSET_OPT) != null && metadata.getPath().equals(offset.get(PATH_OPT))) {
             reader.seek(() -> (Long) offset.get(OFFSET_OPT));
         }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -3,6 +3,7 @@ package com.github.mmolimar.kafka.connect.fs.policy;
 import com.github.mmolimar.kafka.connect.fs.file.FileMetadata;
 import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -27,5 +28,5 @@ public interface Policy extends Closeable {
     SchemaAndValue buildKey(FileMetadata metadata, SchemaAndValue snvValue, Map<String, Object> offset);
     SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset);
     FileMetadata extractExemplar(List<FileMetadata> batchFileMetadata);
-    void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader);
+    void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) throws ConnectException, IOException, IllegalArgumentException;
 }

--- a/src/main/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReader.java
+++ b/src/main/java/com/rentpath/kafka/connect/connectors/filesystem/readers/JsonFileReader.java
@@ -12,6 +12,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.storage.ConverterConfig;
 import org.mortbay.util.ajax.JSON;
@@ -87,7 +88,7 @@ public class JsonFileReader implements FileReader {
     }
 
     @Override
-    public void seek(Offset offset) {
+    public void seek(Offset offset) throws ConnectException, IllegalArgumentException {
         reader.seek(offset);
     }
 


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-2018)

This makes exceptions that might be thrown by the `Reader#seek` method
explicitly declared in an attempt to ensure that they are caught where
they ought to be, and do not bubble up to cause issues deeper in the
stack.