### PR TITLE
Adding watchfile timestamp to metadata

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -314,7 +314,7 @@ public abstract class AbstractPolicy implements Policy {
     }
 
     @Override
-    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset) {
+    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset, String nextRecordPath) {
         SchemaBuilder metadataBuilder = SchemaBuilder.struct()
                 .name("com.rentpath.filesource.Metadata")
                 .optional();

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
@@ -29,6 +29,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
     public static final String WATCHER_POLICY_BATCH_ID_EXTRACTION_INDEX = WATCHER_POLICY_PREFIX + "batch.id.extraction.index";
 
     private static final String PATH_OPT = "path";
+    private static final String NEXT_PATH_OPT = "nextPath";
     private static final String LAST_OPT = "last";
     private static final String LAST_MOD_OPT = "last";
     private static final String WATCH_KEY_OPT = "watchKey";
@@ -142,11 +143,12 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
     }
 
     @Override
-    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset) {
+    public SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset, String nextRecordPath) {
         SchemaBuilder metadataBuilder = SchemaBuilder.struct()
                 .name(WATCHER_METADATA_TYPE)
                 .optional();
         metadataBuilder.field(PATH_OPT, Schema.STRING_SCHEMA);
+        metadataBuilder.field(NEXT_PATH_OPT, Schema.OPTIONAL_STRING_SCHEMA);
         metadataBuilder.field(OFFSET_OPT, Schema.INT64_SCHEMA);
         metadataBuilder.field(LAST_OPT, Schema.BOOLEAN_SCHEMA);
         metadataBuilder.field(BULK_OPT, Schema.BOOLEAN_SCHEMA);
@@ -158,6 +160,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
 
         Struct metadataValue = new Struct(schema);
         metadataValue.put(PATH_OPT, metadata.getPath());
+        metadataValue.put(NEXT_PATH_OPT, nextRecordPath);
         metadataValue.put(OFFSET_OPT, offset);
         metadataValue.put(LAST_OPT, isLast);
         metadataValue.put(BULK_OPT, (Boolean) metadata.getOpt(BULK_OPT));

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/BulkIncrementalPolicy.java
@@ -32,6 +32,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
     private static final String LAST_OPT = "last";
     private static final String LAST_MOD_OPT = "last";
     private static final String WATCH_KEY_OPT = "watchKey";
+    private static final String WATCH_FILE_TIMESTAMP_OPT = "watchFileTimestamp";
     private static final String BULK_OPT = "bulk";
     private static final String WATCH_PATTERN_DELINEATOR = ":::";
     private static final String WATCH_PATTERN_PART_DELINEATOR = ":";
@@ -149,6 +150,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
         metadataBuilder.field(OFFSET_OPT, Schema.INT64_SCHEMA);
         metadataBuilder.field(LAST_OPT, Schema.BOOLEAN_SCHEMA);
         metadataBuilder.field(BULK_OPT, Schema.BOOLEAN_SCHEMA);
+        metadataBuilder.field(WATCH_FILE_TIMESTAMP_OPT, Schema.OPTIONAL_INT64_SCHEMA);
         metadataBuilder.field(WATCH_KEY_OPT, Schema.STRING_SCHEMA);
         metadataBuilder.field(BATCH_ID_OPT, Schema.STRING_SCHEMA);
         metadataBuilder.field(PRIOR_BATCH_ID_OPT, Schema.OPTIONAL_STRING_SCHEMA); // will be null for the very first bulk file we ingest for a given watch key
@@ -159,6 +161,7 @@ public class BulkIncrementalPolicy extends AbstractPolicy {
         metadataValue.put(OFFSET_OPT, offset);
         metadataValue.put(LAST_OPT, isLast);
         metadataValue.put(BULK_OPT, (Boolean) metadata.getOpt(BULK_OPT));
+        metadataValue.put(WATCH_FILE_TIMESTAMP_OPT, lastRead);
         metadataValue.put(WATCH_KEY_OPT, (String) metadata.getOpt(WATCH_KEY_OPT));
         metadataValue.put(BATCH_ID_OPT, (String) connectorOffset.get(BATCH_ID_OPT));
         metadataValue.put(PRIOR_BATCH_ID_OPT, (String) connectorOffset.get(PRIOR_BATCH_ID_OPT));

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -27,7 +27,7 @@ public interface Policy extends Closeable {
     Map<String,Object> buildOffsetPartition(FileMetadata metadata);
     Map<String,Object> buildOffset(FileMetadata metadata, FileMetadata exemplarMetadata, Offset offset, Map<String,Object> priorOffset, boolean isLast);
     SchemaAndValue buildKey(FileMetadata metadata, SchemaAndValue snvValue, Map<String, Object> offset);
-    SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset);
+    SchemaAndValue buildMetadata(FileMetadata metadata, long offset, boolean isLast, Map<String, Object> connectorOffset, String nextRecordPath);
     FileMetadata extractExemplar(List<FileMetadata> batchFileMetadata);
     void seekReader(FileMetadata metadata, Map<String, Object> offset, FileReader reader) throws ConnectException, IOException, IllegalArgumentException;
 }


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-2990)

This adds the last-updated timestamp of the watchfile for the given polling period to the metadata for each produced record.